### PR TITLE
Added sonarqubeapi executor to official

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The current official executors are:
 * [Nuclei][nuclei]
 * [Openvas][openvas]
 * Report processor: Consumes a local report where the dispatcher is with the [faraday plugins][plugins]
+* [Sonar Qube API][sonarqubeapi]
 * [Sublist3r][sublist3r]
 * [W3af][w3af]
 * [Wpscan][wpscan]
@@ -133,6 +134,7 @@ development executors. The most important of them are:
 [nikto]: https://cirt.net/Nikto2
 [nmap]: https://nmap.org
 [nuclei]: https://github.com/projectdiscovery/nuclei
+[sonarqubeapi]: https://www.sonarqube.org/
 [sublist3r]: https://github.com/aboul3la/Sublist3r
 [w3af]: http://w3af.org/
 [wpscan]: https://wpscan.org/

--- a/faraday_agent_dispatcher/static/executors/official/sonarqubeapi.py
+++ b/faraday_agent_dispatcher/static/executors/official/sonarqubeapi.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import json
+import os
+import sys
+import requests
+from faraday_plugins.plugins.manager import PluginsManager
+
+#ATTENTION: We only want to find vulnerabilities. Code smell and bugs doesn't matters for us.
+TYPE_VULNS = 'VULNERABILITY'
+PAGE_SIZE = 500
+
+def main():
+    # If the script is run outside the dispatcher the environment variables
+    # are checked.
+    # ['EXECUTOR_CONFIG_TOKEN', 'EXECUTOR_CONFIG_URL', 'EXECUTOR_CONFIG_PROJECT']
+    try:
+        sonar_qube_url = os.environ["EXECUTOR_CONFIG_URL"]
+        token = os.environ["EXECUTOR_CONFIG_TOKEN"]
+        component_key = os.environ['EXECUTOR_CONFIG_COMPONENT_KEY']
+    except KeyError:
+        print("Environment variable not found", file=sys.stderr)
+        sys.exit()
+
+    session = requests.Session()
+
+    # ATTENTION: SonarQube API requires an empty password when auth method is via token
+    session.auth = (token, '')
+
+    # Issues api config
+    page = 0
+    has_more_vulns = True
+
+    vulnerabilities = []
+
+    while has_more_vulns:
+        page += 1
+
+        params = {
+            'componentKeys': component_key,
+            'types': TYPE_VULNS,
+            'p': page,
+            'ps': PAGE_SIZE
+        }
+
+        response = session.get(
+            url=f'{sonar_qube_url}/api/issues/search',
+            params=params,
+        )
+
+        if not response.ok:
+            print(
+                f"There was an error finding issues. Component Key {component_key}; Status Code {response.status_code} - {response.content}",
+                file=sys.stderr)
+            sys.exit()
+
+        response_json = response.json()
+        issues = response_json.get('issues')
+        vulnerabilities.extend(issues)
+        total_items = response_json.get('paging').get('total')
+
+        has_more_vulns = page * PAGE_SIZE < total_items
+
+    plugin = PluginsManager().get_plugin("sonarqubeapi")
+
+    vulns_json = json.dumps({'issues': vulnerabilities})
+    plugin.parseOutputString(vulns_json)
+    print(plugin.get_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/faraday_agent_dispatcher/static/executors/official/sonarqubeapi_manifest.json
+++ b/faraday_agent_dispatcher/static/executors/official/sonarqubeapi_manifest.json
@@ -1,0 +1,13 @@
+{
+  "arguments": {
+    "URL": true,
+    "TOKEN": true,
+    "COMPONENT_KEY": true
+  },
+  "environment_variables": [
+  ],
+  "check_cmds": [
+
+  ],
+  "cmd": "python3 {EXECUTOR_FILE_PATH}"
+}


### PR DESCRIPTION
Based on a suggestion in [this PR on faraday_plugins](https://github.com/infobyte/faraday_plugins/pull/7), I've created a new official executor for Sonar Qube API. 

This executor query the Sonar Qube issues API and finds all the vulnerabilities of a project. Then uses the previously mentioned plugin to upload the found vulns to Faraday.

Important Note: the Sonar Qube issues API is [described here](https://jira.sonarsource.com/browse/MMF-1672). In that JIRA ticket, the creator explains that the max page size is 500 so we need to iterate over the API response until fetching all items using the paging approach.

_Faraday Dashboard_
![image](https://user-images.githubusercontent.com/1610232/118204318-5a3a4780-b434-11eb-9b92-e2d68f3c06f1.png)

_Agent List_
![image](https://user-images.githubusercontent.com/1610232/118204371-71793500-b434-11eb-8027-657e34d9fdf6.png)

_Executor Params_
![image](https://user-images.githubusercontent.com/1610232/118204535-cae16400-b434-11eb-936e-041a90f07e13.png)
