### PR TITLE
changed default gvmd socket location

### DIFF
--- a/faraday_agent_dispatcher/static/executors/official/gvm_openvas.py
+++ b/faraday_agent_dispatcher/static/executors/official/gvm_openvas.py
@@ -67,7 +67,7 @@ def main():
 
     if connection_type == "socket":
         # Default Socket according to official docs
-        socket = "/var/run/gvmd.sock" if not socket else socket
+        socket = "/var/run/gvmd/gvmd.sock" if not socket else socket
     elif connection_type == "ssh":
         if not userssh or not passwssh:
             print("SSH username or password not provided", file=sys.stderr)


### PR DESCRIPTION
The default socket path for the Greenbone OpenVAS agent in Faraday was incorrect. It has been updated from:
/run/gvmd.sock
to:
/run/gvmd/gvmd.sock.

This change aligns with the official Greenbone documentation for connection types:
https://greenbone.github.io/gvm-tools/connectiontypes.html